### PR TITLE
geom_alt props

### DIFF
--- a/data/421/176/813/421176813.geojson
+++ b/data/421/176/813/421176813.geojson
@@ -425,6 +425,9 @@
     },
     "wof:country":"ST",
     "wof:created":1459009120,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"430211b222da8c1fbfce26af851b02a3",
     "wof:hierarchy":[
         {
@@ -435,7 +438,7 @@
         }
     ],
     "wof:id":421176813,
-    "wof:lastmodified":1566650649,
+    "wof:lastmodified":1582319406,
     "wof:name":"Sao Tome",
     "wof:parent_id":85677301,
     "wof:placetype":"locality",

--- a/data/856/327/65/85632765.geojson
+++ b/data/856/327/65/85632765.geojson
@@ -1000,7 +1000,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1070,7 +1069,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1582319406,
+    "wof:lastmodified":1583206129,
     "wof:name":"Sao Tome and Principe",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/327/65/85632765.geojson
+++ b/data/856/327/65/85632765.geojson
@@ -1000,6 +1000,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1051,6 +1052,10 @@
     },
     "wof:country":"ST",
     "wof:country_alpha3":"STP",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"741a22f396b8656b0ea09624a1c06ba2",
     "wof:hierarchy":[
         {
@@ -1065,7 +1070,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566650631,
+    "wof:lastmodified":1582319406,
     "wof:name":"Sao Tome and Principe",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.