### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/114/190/621/9/1141906219.geojson
+++ b/data/114/190/621/9/1141906219.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"7.41200448319,1.64500205056,7.41200448319,1.64500205056",
+    "geom:bbox":"7.412004,1.645002,7.412004,1.645002",
     "geom:latitude":1.645002,
     "geom:longitude":7.412004,
     "iso:country":"ST",
@@ -23,6 +23,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0430\u043d\u0442\u0443-\u0410\u043d\u0442\u043e\u043d\u044c\u044e"
+    ],
+    "name:bel_x_variant":[
+        "\u0421\u0430\u043d\u0442\u0443-\u0410\u043d\u0442\u043e\u043d\u044c\u044e"
     ],
     "name:bre_x_preferred":[
         "Santo Ant\u00f3nio"
@@ -57,10 +60,16 @@
     "name:fra_x_preferred":[
         "Santo Ant\u00f3nio"
     ],
+    "name:frr_x_preferred":[
+        "Santo Ant\u00f3nio"
+    ],
     "name:heb_x_preferred":[
         "\u05e1\u05e0\u05d8\u05d5 \u05d0\u05e0\u05d8\u05d5\u05e0\u05d9\u05d5"
     ],
     "name:hrv_x_preferred":[
+        "Santo Ant\u00f3nio"
+    ],
+    "name:ind_x_preferred":[
         "Santo Ant\u00f3nio"
     ],
     "name:ita_x_preferred":[
@@ -116,6 +125,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e0b\u0e31\u0e07\u0e15\u0e39\u0e2d\u0e31\u0e07\u0e15\u0e2d\u0e19\u0e35\u0e2d\u0e39"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0421\u0430\u043d\u0442\u0443-\u0410\u043d\u0442\u043e\u043d\u0456\u043e"
     ],
     "name:urd_x_preferred":[
         "\u0633\u0627\u0646\u062a\u0648 \u0627\u0646\u062a\u0648\u0646\u06cc\u0648"
@@ -230,7 +242,7 @@
     },
     "wof:country":"ST",
     "wof:created":1499130558,
-    "wof:geomhash":"e42b939e2ee5a0af0fdb6f2e2f783b76",
+    "wof:geomhash":"879efdeb2c50bf29747558a5a6275b18",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -240,7 +252,7 @@
         }
     ],
     "wof:id":1141906219,
-    "wof:lastmodified":1566650661,
+    "wof:lastmodified":1690866754,
     "wof:name":"Santo Antonio",
     "wof:parent_id":85677303,
     "wof:placetype":"locality",
@@ -250,10 +262,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    7.41200448319086,
-    1.64500205055794,
-    7.41200448319086,
-    1.64500205055794
+    7.412004,
+    1.645002,
+    7.412004,
+    1.645002
 ],
-  "geometry": {"coordinates":[7.41200448319086,1.64500205055794],"type":"Point"}
+  "geometry": {"coordinates":[7.412004,1.645002],"type":"Point"}
 }

--- a/data/421/176/813/421176813.geojson
+++ b/data/421/176/813/421176813.geojson
@@ -28,8 +28,20 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0648 \u062a\u0648\u0645\u064a"
     ],
+    "name:arg_x_preferred":[
+        "Sant Tom\u00e9"
+    ],
+    "name:ary_x_preferred":[
+        "\u0633\u0627\u0648 \u0637\u0648\u0645\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0648 \u062a\u0648\u0645\u0649"
+    ],
     "name:ast_x_preferred":[
         "Santu Tom\u00e9"
+    ],
+    "name:avk_x_preferred":[
+        "S\u00e3o Tom\u00e9"
     ],
     "name:aze_x_preferred":[
         "San-Tome"
@@ -40,6 +52,9 @@
     "name:bak_x_preferred":[
         "\u0421\u0430\u043d-\u0422\u043e\u043c\u0435"
     ],
+    "name:ban_x_preferred":[
+        "S\u00e3o Tom\u00e9"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0430\u043d-\u0422\u0430\u043c\u044d"
     ],
@@ -48,6 +63,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09be\u0993 \u09a4\u09ae\u09c7"
+    ],
+    "name:ben_x_variant":[
+        "\u09b8\u09be\u0981\u0989 \u09a4\u09c1\u09ae\u09c7"
     ],
     "name:bod_x_preferred":[
         "\u0f66\u0f60\u0f7c\u0f0b\u0f4a\u0f7c\u0f0b\u0f58\u0f7a\u0f0d"
@@ -106,6 +124,9 @@
     "name:epo_x_preferred":[
         "Sao-Tomeo"
     ],
+    "name:epo_x_variant":[
+        "Santomeo"
+    ],
     "name:est_x_preferred":[
         "S\u00e3o Tom\u00e9"
     ],
@@ -122,6 +143,9 @@
         "S\u00e3o Tom\u00e9"
     ],
     "name:fra_x_preferred":[
+        "S\u00e3o Tom\u00e9"
+    ],
+    "name:frr_x_preferred":[
         "S\u00e3o Tom\u00e9"
     ],
     "name:fry_x_preferred":[
@@ -144,6 +168,9 @@
     ],
     "name:hat_x_preferred":[
         "Sao Tome"
+    ],
+    "name:hau_x_preferred":[
+        "S\u00e3o Tom\u00e9"
     ],
     "name:heb_x_preferred":[
         "\u05e1\u05d0\u05d5 \u05d8\u05d5\u05de\u05d4"
@@ -169,7 +196,13 @@
     "name:ido_x_variant":[
         "Sao Tome"
     ],
+    "name:ina_x_preferred":[
+        "S\u00e3o Tom\u00e9"
+    ],
     "name:ind_x_preferred":[
+        "S\u00e3o Tom\u00e9"
+    ],
+    "name:isl_x_preferred":[
         "S\u00e3o Tom\u00e9"
     ],
     "name:ita_x_preferred":[
@@ -223,6 +256,9 @@
     "name:mar_x_preferred":[
         "\u0938\u093e\u0913 \u091f\u094b\u092e\u0947"
     ],
+    "name:mdf_x_preferred":[
+        "\u0421\u0430\u043d-\u0422\u043e\u043c\u044d"
+    ],
     "name:mkd_x_preferred":[
         "\u0421\u0430\u043e \u0422\u043e\u043c\u0435"
     ],
@@ -237,6 +273,9 @@
     ],
     "name:msa_x_preferred":[
         "S\u00e3o Tom\u00e9"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0633\u0627\u0626\u0648\u062a\u0648\u0645\u0647"
     ],
     "name:nan_x_preferred":[
         "S\u00e3o Tom\u00e9"
@@ -261,6 +300,12 @@
     ],
     "name:oci_x_preferred":[
         "S\u00e3o Tom\u00e9"
+    ],
+    "name:olo_x_preferred":[
+        "San Tome"
+    ],
+    "name:oss_x_preferred":[
+        "\u0421\u0430\u043d-\u0422\u043e\u043c\u0435"
     ],
     "name:pan_x_preferred":[
         "\u0a38\u0a3e\u0a13 \u0a24\u0a4b\u0a2e\u0a47"
@@ -301,6 +346,9 @@
     "name:slv_x_preferred":[
         "S\u00e3o Tom\u00e9"
     ],
+    "name:smn_x_preferred":[
+        "S\u00e3o Tom\u00e9"
+    ],
     "name:sna_x_preferred":[
         "S\u00e3o Tom\u00e9"
     ],
@@ -312,6 +360,9 @@
     ],
     "name:sqi_x_preferred":[
         "Sao Tome"
+    ],
+    "name:srd_x_preferred":[
+        "S\u00e3o Tom\u00e9"
     ],
     "name:srp_x_preferred":[
         "\u0421\u0430\u043e \u0422\u043e\u043c\u0435"
@@ -325,6 +376,9 @@
     "name:tam_x_preferred":[
         "\u0b9a\u0bbe\u0bb5\u0bcb \u0ba4\u0bca\u0bae\u0bc7"
     ],
+    "name:tat_x_preferred":[
+        "\u0421\u0430\u043d-\u0422\u043e\u043c\u0435"
+    ],
     "name:tel_x_preferred":[
         "\u0c38\u0c3e\u0c35\u0c4b \u0c24\u0c4b\u0c2e\u0c46"
     ],
@@ -336,6 +390,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e32\u0e15\u0e39\u0e40\u0e21"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e0b\u0e32\u0e15\u0e39\u0e41\u0e21"
     ],
     "name:tur_x_preferred":[
         "S\u00e3o Tom\u00e9"
@@ -440,7 +497,7 @@
         }
     ],
     "wof:id":421176813,
-    "wof:lastmodified":1617130307,
+    "wof:lastmodified":1690866754,
     "wof:name":"Sao Tome",
     "wof:parent_id":85677301,
     "wof:placetype":"locality",

--- a/data/421/201/975/421201975.geojson
+++ b/data/421/201/975/421201975.geojson
@@ -23,6 +23,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0430\u043d\u0442\u0443-\u0410\u043d\u0442\u043e\u043d\u044c\u044e"
     ],
+    "name:bel_x_variant":[
+        "\u0421\u0430\u043d\u0442\u0443-\u0410\u043d\u0442\u043e\u043d\u044c\u044e"
+    ],
     "name:bre_x_preferred":[
         "Santo Ant\u00f3nio"
     ],
@@ -56,10 +59,16 @@
     "name:fra_x_preferred":[
         "Santo Ant\u00f3nio"
     ],
+    "name:frr_x_preferred":[
+        "Santo Ant\u00f3nio"
+    ],
     "name:heb_x_preferred":[
         "\u05e1\u05e0\u05d8\u05d5 \u05d0\u05e0\u05d8\u05d5\u05e0\u05d9\u05d5"
     ],
     "name:hrv_x_preferred":[
+        "Santo Ant\u00f3nio"
+    ],
+    "name:ind_x_preferred":[
         "Santo Ant\u00f3nio"
     ],
     "name:ita_x_preferred":[
@@ -119,6 +128,9 @@
     "name:tha_x_preferred":[
         "\u0e0b\u0e31\u0e07\u0e15\u0e39\u0e2d\u0e31\u0e07\u0e15\u0e2d\u0e19\u0e35\u0e2d\u0e39"
     ],
+    "name:ukr_x_preferred":[
+        "\u0421\u0430\u043d\u0442\u0443-\u0410\u043d\u0442\u043e\u043d\u0456\u043e"
+    ],
     "name:und_x_variant":[
         "San Antonio"
     ],
@@ -173,7 +185,7 @@
         }
     ],
     "wof:id":421201975,
-    "wof:lastmodified":1566650649,
+    "wof:lastmodified":1690866754,
     "wof:name":"Santo Ant\u00f3nio",
     "wof:parent_id":85677303,
     "wof:placetype":"locality",

--- a/data/856/327/65/85632765.geojson
+++ b/data/856/327/65/85632765.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
+    "name:abk_x_preferred":[
+        "\u0421\u0430\u043d-\u0422\u043e\u043c\u0435\u0438 \u041f\u0440\u0438\u043d\u0441\u0438\u043f\u0438\u0438"
+    ],
     "name:afr_x_preferred":[
         "S\u00e3o Tom\u00e9 en Pr\u00edncipe"
     ],
@@ -48,6 +51,12 @@
     "name:amh_x_variant":[
         "\u1233\u12a6 \u1276\u121c \u12a5\u1293 \u1355\u122a\u1295\u1232\u1354"
     ],
+    "name:ami_x_preferred":[
+        "Sao tome and principe"
+    ],
+    "name:anp_x_preferred":[
+        "\u0938\u093e\u0913 \u091f\u094b\u092e\u0947 \u0906\u0930\u094b \u092a\u094d\u0930\u093f\u0902\u0938\u093f\u092a\u0947"
+    ],
     "name:ara_x_preferred":[
         "\u0633\u0627\u0648 \u062a\u0648\u0645\u064a \u0648\u0628\u0631\u064a\u0646\u0633\u064a\u0628"
     ],
@@ -61,8 +70,14 @@
     "name:arg_x_variant":[
         "San Tom\u00e9 y Prenzipe"
     ],
+    "name:ary_x_preferred":[
+        "\u0635\u0627\u0648 \u0637\u0648\u0645\u064a \u0624\u067e\u0631\u0627\u0646\u0633\u064a\u067e\u064a"
+    ],
     "name:arz_x_preferred":[
         "\u0633\u0627\u0648\u062a\u0648\u0645\u0649 \u0648\u0628\u0631\u0646\u0633\u064a\u0628\u0649"
+    ],
+    "name:arz_x_variant":[
+        "\u0633\u0627\u0648 \u062a\u0648\u0645\u0649 \u0648 \u067e\u0631\u064a\u0646\u0633\u064a\u067e\u0649"
     ],
     "name:ast_x_preferred":[
         "S\u00e3o Tom\u00e9 y Pr\u00edncipe"
@@ -87,6 +102,12 @@
     "name:bam_x_preferred":[
         "Sawo Tome-ni-Prinicipe"
     ],
+    "name:ban_x_preferred":[
+        "Sao Tom\u00e9 miwah Principe"
+    ],
+    "name:bar_x_preferred":[
+        "S\u00e3o Tom\u00e9 u Pr\u00edncipe"
+    ],
     "name:bcl_x_preferred":[
         "Santo Tome asin Prinsipe"
     ],
@@ -104,6 +125,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0938\u093e\u0913 \u091f\u094b\u092e \u0905\u0909\u0930\u0940 \u092a\u094d\u0930\u093f\u0902\u0938\u0947\u092a"
+    ],
+    "name:bis_x_preferred":[
+        "Sao Tome mo Prinsip"
     ],
     "name:bod_x_preferred":[
         "\u0f66\u0f0b\u0f60\u0f7c\u0f0b\u0f4f\u0f7c\u0f51\u0f0b\u0f58\u0f51\u0f0d \u0f51\u0f44\u0f0c\u0f0d \u0f54\u0f84\u0f62\u0f72\u0f53\u0f0b\u0f66\u0f72\u0f0b\u0f54\u0f7a\u0f0d"
@@ -220,6 +244,9 @@
     "name:epo_x_preferred":[
         "Sao-Tomeo kaj Principeo"
     ],
+    "name:epo_x_variant":[
+        "Santomeo kaj Principeo"
+    ],
     "name:est_x_preferred":[
         "Sao Tom\u00e9 ja Principe"
     ],
@@ -282,8 +309,14 @@
     "name:ful_x_preferred":[
         "Sawo Tome e Perensipe"
     ],
+    "name:ful_x_variant":[
+        "Sawo Tome"
+    ],
     "name:gag_x_preferred":[
         "San Tome hem Prinsipi"
+    ],
+    "name:gcr_x_preferred":[
+        "Sao Tom\u00e9-\u00e9-Prensip"
     ],
     "name:gla_x_preferred":[
         "S\u00e3o Tom\u00e9 agus Pr\u00edncipe"
@@ -304,6 +337,9 @@
     "name:glv_x_preferred":[
         "S\u00e3o Tom\u00e9 as Pr\u00edncipe"
     ],
+    "name:gpe_x_preferred":[
+        "S\u00e3o Tom\u00e9 and Pr\u00edncipe"
+    ],
     "name:grn_x_preferred":[
         "Santo Tome ha Pr\u00edncipe"
     ],
@@ -315,6 +351,9 @@
     ],
     "name:guj_x_variant":[
         "\u0ab8\u0abe\u0a93 \u0aa4\u0acb\u0aae \u0aaa\u0acd\u0ab0\u0abf\u0aa8\u0acd\u0ab8\u0abf\u0aaa\u0ac0"
+    ],
+    "name:gur_x_preferred":[
+        "S\u00e3oTom\u00e9 and Pr\u00edncipe"
     ],
     "name:hak_x_preferred":[
         "S\u00e3o Tom\u00e9 l\u00e2u Pr\u00edncipe"
@@ -506,6 +545,9 @@
         "San Tom\u0117 ir Prinsip\u0117",
         "S\u00e3o Tom\u00e9 ir Pr\u00edncipe"
     ],
+    "name:lld_x_preferred":[
+        "S\u00e3o Tom\u00e9 y Pr\u00edncipe"
+    ],
     "name:lmo_x_preferred":[
         "S\u00e3o Tom\u00e9 e Pr\u00edncipe"
     ],
@@ -536,8 +578,14 @@
     "name:mar_x_variant":[
         "\u0938\u093e\u0913 \u091f\u094b\u092e\u0947 \u0906\u0923\u093f \u092a\u094d\u0930\u093f\u0928\u094d\u0938\u093f\u092a"
     ],
+    "name:mdf_x_preferred":[
+        "\u0421\u0430\u043d-\u0422\u043e\u043c\u044d \u0434\u0438 \u041f\u0440\u0438\u043d\u0441\u0438\u043f\u0438"
+    ],
     "name:mhr_x_preferred":[
         "\u0421\u0430\u043d-\u0422\u043e\u043c\u0435 \u0434\u0430 \u041f\u0440\u0438\u043d\u0441\u0438\u043f\u0438"
+    ],
+    "name:min_x_preferred":[
+        "Sao Tome jo Principe"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u0430\u043e \u0422\u043e\u043c\u0435 \u0438 \u041f\u0440\u0438\u043d\u0447\u0438\u043f\u0435"
@@ -556,6 +604,12 @@
     ],
     "name:mlt_x_variant":[
         "S\u00e3o Tom\u00e9 u Pr\u00edncipe"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc1\uabe5\uabd1\uabe3 \uabc7\uabe3\uabc3\uabe6 \uabd1\uabc3\uabd7\uabe4 \uabc4\uabed\uabd4\uabe4\uabdf\uabc1\uabe4\uabc4\uabe6"
+    ],
+    "name:mon_x_preferred":[
+        "\u0421\u0430\u043d-\u0422\u043e\u043c\u0435 \u0431\u0430 \u041f\u0440\u0438\u043d\u0441\u0438\u043f\u0438"
     ],
     "name:mri_x_preferred":[
         "Ao Tomi me Pirinihipi"
@@ -582,6 +636,9 @@
     "name:nan_x_preferred":[
         "S\u00e3o Tom\u00e9 kap Pr\u00edncipe"
     ],
+    "name:nau_x_preferred":[
+        "S\u00e3o Tom\u00e9 and Pr\u00edncipe"
+    ],
     "name:nde_x_preferred":[
         "S\u00e3o Tom\u00e9 and Pr\u00edncipe"
     ],
@@ -592,7 +649,11 @@
         "\u0938\u093e\u0913 \u091f\u094b\u092e\u0947 \u0930 \u092a\u094d\u0930\u093f\u0928\u094d\u0938\u093f\u092a"
     ],
     "name:nep_x_variant":[
-        "\u0938\u093e\u0913 \u091f\u094b\u092e\u0947 \u0930 \u092a\u094d\u0930\u093f\u0928\u094d\u0938\u093f\u092a\u0947"
+        "\u0938\u093e\u0913 \u091f\u094b\u092e\u0947 \u0930 \u092a\u094d\u0930\u093f\u0928\u094d\u0938\u093f\u092a\u0947",
+        "\u0938\u093e\u0913 \u0924\u094b\u092e\u0947 \u0930 \u092a\u094d\u0930\u093f\u0928\u094d\u0938\u093f\u092a\u0940"
+    ],
+    "name:new_x_preferred":[
+        "\u0938\u093e\u0913 \u091f\u094b\u092e\u0947 \u0935 \u092a\u094d\u0930\u093f\u0928\u094d\u0938\u093f\u092a"
     ],
     "name:nld_x_colloquial":[
         "Sao Tome-en-Principe"
@@ -681,6 +742,9 @@
     "name:pus_x_preferred":[
         "\u0633\u0627\u0648\u062a\u0648\u0645\u06d0 \u0627\u0648 \u067e\u0631\u0646\u0633\u064a\u067e\u0647"
     ],
+    "name:pus_x_variant":[
+        "\u0633\u0627\u06cc\u0648\u062a\u0648\u0645\u0647 \u0627\u0648 \u067e\u0631\u0646\u0633\u06cc\u067e"
+    ],
     "name:que_x_preferred":[
         "Santu Tumiy Prinsipipas"
     ],
@@ -722,6 +786,9 @@
     "name:sgs_x_preferred":[
         "San Tuom\u0117 \u0117 Pr\u0117ns\u0117p\u0117"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101e\u1030\u107c\u103a\u1087\u1010\u1030\u101d\u103a\u1087\u1019\u1031\u1038 \u101c\u1084\u1088 \u1015\u101b\u102d\u107c\u103a\u1087\u101e\u102e\u1087\u1015\u1031\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc3\u0dcf\u0d95 \u0da7\u0ddc\u0db8\u0dda \u0dc3\u0dc4 \u0db4\u0dca\u200d\u0dbb\u0dd2\u0db1\u0dca\u0dc3\u0dd2\u0db4\u0dda"
     ],
@@ -736,8 +803,20 @@
     "name:slv_x_preferred":[
         "Sao Tome in Principe"
     ],
+    "name:slv_x_variant":[
+        "Sveti Toma\u017e in Princ"
+    ],
     "name:sme_x_preferred":[
         "S\u00e3o Tom\u00e9 ja Pr\u00edncipe"
+    ],
+    "name:smn_x_preferred":[
+        "S\u00e3o Tom\u00e9 j\u00e1 Principe"
+    ],
+    "name:smo_x_preferred":[
+        "S\u00e3o Tom\u00e9 ma Pr\u00edncipe"
+    ],
+    "name:sms_x_preferred":[
+        "S\u00e3o Tom\u00e9 da Principe"
     ],
     "name:sna_x_preferred":[
         "S\u00e3o Tom\u00e9 and Pr\u00edncipe"
@@ -797,6 +876,9 @@
     "name:swe_x_variant":[
         "S\u00e3o Tom\u00e9 och Pr\u00edncipe"
     ],
+    "name:szy_x_preferred":[
+        "Sao tome and principe"
+    ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bbe\u0bb5\u0bcd \u0ba4\u0bcb\u0bae\u0bcd \u0bae\u0bb1\u0bcd\u0bb1\u0bc1\u0bae\u0bcd \u0baa\u0bcd\u0bb0\u0bbf\u0ba9\u0bcd\u0b9a\u0bbf\u0baa\u0bbf"
     ],
@@ -814,6 +896,9 @@
     ],
     "name:tet_x_preferred":[
         "Saun Tom\u00e9 no Pr\u00ednsipe"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0430\u043d-\u0422\u043e\u043c\u0435 \u0432\u0430 \u041f\u0440\u0438\u043d\u0441\u0438\u043f\u0438"
     ],
     "name:tgl_x_preferred":[
         "S\u00e3o Tom\u00e9 at Pr\u00edncipe"
@@ -833,6 +918,9 @@
     ],
     "name:ton_x_preferred":[
         "Sao Tome mo Pilinisipe"
+    ],
+    "name:trv_x_preferred":[
+        "S\u00e3o Tom\u00e9 and Pr\u00edncipe"
     ],
     "name:tuk_x_preferred":[
         "San-Tome we Prinsipi"
@@ -909,6 +997,9 @@
     ],
     "name:yor_x_variant":[
         "Sao Tome \u00e0ti Principe"
+    ],
+    "name:zea_x_preferred":[
+        "S\u00e3o Tom\u00e9 e Pr\u00edncipe"
     ],
     "name:zha_x_preferred":[
         "S\u00e3o Tom\u00e9 caeuq Pr\u00edncipe"
@@ -1135,7 +1226,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1617827414,
+    "wof:lastmodified":1690866753,
     "wof:name":"Sao Tome and Principe",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/773/01/85677301.geojson
+++ b/data/856/773/01/85677301.geojson
@@ -44,6 +44,9 @@
     "name:ceb_x_preferred":[
         "S\u00e3o Tom\u00e9"
     ],
+    "name:cym_x_preferred":[
+        "Talaith S\u00e3o Tom\u00e9"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03ac\u03bf \u03a4\u03bf\u03bc\u03ad"
     ],
@@ -56,6 +59,9 @@
     "name:epo_x_preferred":[
         "Provinco Sao-Tomeo"
     ],
+    "name:epo_x_variant":[
+        "Provinco Santomeo"
+    ],
     "name:est_x_preferred":[
         "S\u00e3o Tom\u00e9 saar"
     ],
@@ -64,6 +70,9 @@
     ],
     "name:glg_x_preferred":[
         "Illa de San Tom\u00e9"
+    ],
+    "name:gpe_x_preferred":[
+        "S\u00e3o Tom\u00e9 Province"
     ],
     "name:ind_x_preferred":[
         "Pulau S\u00e3o Tom\u00e9"
@@ -89,6 +98,9 @@
     ],
     "name:nld_x_preferred":[
         "Sao Tom\u00e9"
+    ],
+    "name:nld_x_variant":[
+        "provincie S\u00e3o Tom\u00e9"
     ],
     "name:nob_x_preferred":[
         "S\u00e3o Tom\u00e9"
@@ -256,7 +268,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1614895910,
+    "wof:lastmodified":1690866753,
     "wof:name":"S\u00e3o Tom\u00e9",
     "wof:parent_id":85632765,
     "wof:placetype":"region",

--- a/data/856/773/03/85677303.geojson
+++ b/data/856/773/03/85677303.geojson
@@ -41,6 +41,9 @@
     "name:ceb_x_preferred":[
         "Pr\u00edncipe"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Pr\u00edncipe"
+    ],
     "name:ell_x_preferred":[
         "\u03a0\u03c1\u03af\u03bd\u03c3\u03b9\u03c0\u03b5"
     ],
@@ -123,6 +126,9 @@
     ],
     "name:zho_x_preferred":[
         "\u666e\u6797\u897f\u6bd4\u5c9b"
+    ],
+    "name:zho_x_variant":[
+        "\u666e\u6797\u897f\u6bd4\u81ea\u6cbb\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"STP",
@@ -241,7 +247,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1614895910,
+    "wof:lastmodified":1690866753,
     "wof:name":"Pr\u00edncipe",
     "wof:parent_id":85632765,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.