### PR TITLE
st concordances, placetype local, and more

### DIFF
--- a/data/856/327/65/85632765.geojson
+++ b/data/856/327/65/85632765.geojson
@@ -1198,6 +1198,7 @@
         "hasc:id":"ST",
         "icao:code":"S9",
         "ioc:id":"STP",
+        "iso:code":"ST",
         "itu:id":"STP",
         "m49:code":"678",
         "marc:id":"sf",
@@ -1210,6 +1211,7 @@
         "wk:page":"S\u00e3o Tom\u00e9 and Pr\u00edncipe",
         "wmo:id":"TP"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ST",
     "wof:country_alpha3":"STP",
     "wof:geom_alt":[
@@ -1230,7 +1232,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1694639513,
+    "wof:lastmodified":1695881168,
     "wof:name":"Sao Tome and Principe",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/773/01/85677301.geojson
+++ b/data/856/773/01/85677301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071565,
-    "geom:area_square_m":884905587.675248,
+    "geom:area_square_m":884905932.479735,
     "geom:bbox":"6.461681,0.024115,6.760916,0.410793",
     "geom:latitude":0.235565,
     "geom:longitude":6.607635,
@@ -246,14 +246,16 @@
         "gn:id":2410764,
         "gp:id":2347234,
         "hasc:id":"ST.ST",
+        "iso:code":"ST-S",
         "iso:id":"ST-S",
         "qs_pg:id":319010,
         "unlc:id":"ST-S",
         "wd:id":"Q6710363",
         "wk:page":"S\u00e3o Tom\u00e9 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ST",
-    "wof:geomhash":"7f99ab494cafd26501cd9f0259978a28",
+    "wof:geomhash":"37e5b3e575c70b357ad0764797d1f302",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -268,7 +270,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690866753,
+    "wof:lastmodified":1695884535,
     "wof:name":"S\u00e3o Tom\u00e9",
     "wof:parent_id":85632765,
     "wof:placetype":"region",

--- a/data/856/773/03/85677303.geojson
+++ b/data/856/773/03/85677303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0127,
-    "geom:area_square_m":156977665.039266,
+    "geom:area_square_m":156977107.350798,
     "geom:bbox":"7.329356,1.531195,7.462738,1.699774",
     "geom:latitude":1.620246,
     "geom:longitude":7.395916,
@@ -225,14 +225,16 @@
         "gn:id":2410878,
         "gp:id":2347233,
         "hasc:id":"ST.PR",
+        "iso:code":"ST-P",
         "iso:id":"ST-P",
         "qs_pg:id":1097076,
         "unlc:id":"ST-P",
         "wd:id":"Q2366966",
         "wk:page":"Pr\u00edncipe Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ST",
-    "wof:geomhash":"6cd32a13cb51fb1e6ca6c92f08c16555",
+    "wof:geomhash":"9442a13b3e393a0cb515903ab38fb58b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -247,7 +249,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690866753,
+    "wof:lastmodified":1695884535,
     "wof:name":"Pr\u00edncipe",
     "wof:parent_id":85632765,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.